### PR TITLE
Removed reference to CoreKeywordDescriptors.ForwardPlus for Unity 6.1

### DIFF
--- a/Editor/ShaderGraph/Targets/UniversalSimpleLitSubTarget.cs
+++ b/Editor/ShaderGraph/Targets/UniversalSimpleLitSubTarget.cs
@@ -872,7 +872,8 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 { CoreKeywordDescriptors.LightLayers },
                 { CoreKeywordDescriptors.DebugDisplay },
                 { CoreKeywordDescriptors.LightCookies },
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_6000_1_OR_NEWER
+#elif UNITY_2022_2_OR_NEWER
                 { CoreKeywordDescriptors.ForwardPlus },
 #else
                 { CoreKeywordDescriptors.ClusteredRendering },


### PR DESCRIPTION
This makes it work for Unity 6.1.13 (I haven't checked prior 6.1 Unity versions).