### PR TITLE
Fix issue in 6000.1 where ForwardPLus keyworld was replaced with Clus…

### DIFF
--- a/Editor/ShaderGraph/Targets/UniversalSimpleLitSubTarget.cs
+++ b/Editor/ShaderGraph/Targets/UniversalSimpleLitSubTarget.cs
@@ -872,8 +872,10 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 { CoreKeywordDescriptors.LightLayers },
                 { CoreKeywordDescriptors.DebugDisplay },
                 { CoreKeywordDescriptors.LightCookies },
-#if UNITY_2022_2_OR_NEWER
-                { CoreKeywordDescriptors.ForwardPlus },
+#if UNITY_6000_1_OR_NEWER
+              { CoreKeywordDescriptors.ClusterLightLoop },
+#elif UNITY_2022_2_OR_NEWER
+              { CoreKeywordDescriptors.ForwardPlus },
 #else
                 { CoreKeywordDescriptors.ClusteredRendering },
 #endif


### PR DESCRIPTION
…terLightLoop

In 6000.1 the CoreKeywordDescriptor.ForwardPlus (_FORWARD_PLUS) was replaced with CoreKeywordDescriptor.ClusterLightLoop (_CLUSTER_LIGHT_LOOP)

Documentation can be found here
6000.1: https://docs.unity3d.com/6000.1/Documentation/Manual/urp/urp-shaders/shader-keywords-macros.html 6000.0: https://docs.unity3d.com/6000.0/Documentation/Manual/urp/urp-shaders/shader-keywords-macros.html

Fixes issue here:
#27 
Improves on pull request #25