### PR TITLE
Fixed BlendAlpha mode broken in Unity 6.2

### DIFF
--- a/Editor/ShaderGraph/Targets/UniversalSimpleLitSubTarget.cs
+++ b/Editor/ShaderGraph/Targets/UniversalSimpleLitSubTarget.cs
@@ -190,6 +190,17 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
 #endif
                 collector.AddFloatProperty(Property.SrcBlend, 1.0f);    // always set by material inspector, ok to have incorrect values here
                 collector.AddFloatProperty(Property.DstBlend, 0.0f);    // always set by material inspector, ok to have incorrect values here
+                // Set alpha blend defaults based on surface type
+                collector.AddFloatProperty(Property.SrcBlendAlpha, 1.0f);    // One - used for both opaque and transparent
+                if (target.surfaceType == SurfaceType.Opaque)
+                {
+                    collector.AddFloatProperty(Property.DstBlendAlpha, 0.0f);    // Zero for opaque
+                }
+                else
+                {
+                    collector.AddFloatProperty(Property.DstBlendAlpha, 10.0f);   // OneMinusSrcAlpha for transparent (always set by material inspector)
+                }
+                
                 collector.AddToggleProperty(Property.ZWrite, (target.surfaceType == SurfaceType.Opaque));
                 collector.AddFloatProperty(Property.ZWriteControl, (float)target.zWriteControl);
                 collector.AddFloatProperty(Property.ZTest, (float)target.zTestMode);    // ztest mode is designed to directly pass as ztest


### PR DESCRIPTION
Resolved issue with BlendAlpha on all SimpleLit materials being forced to Zero/Zero by explicitly defining parameters in subtarget. 

This was causing passthrough mode for MetaXR to show over all opaque objects, making them appear transparent